### PR TITLE
Create temp config files for InfluxServer

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 [![Build Status](https://travis-ci.org/benjamin-bader/embedded-influx.svg?branch=master)](https://travis-ci.org/benjamin-bader/embedded-influx)
 
+The currently bundled version of influxd is 1.7.0. 
+
 Use like so:
 
 ```kotlin

--- a/embedded-influx-junit4/src/main/kotlin/com/bendb/influx/InfluxServerRule.kt
+++ b/embedded-influx-junit4/src/main/kotlin/com/bendb/influx/InfluxServerRule.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018 Benjamin Bader.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.bendb.influx
 
 import org.junit.rules.ExternalResource
@@ -24,7 +39,8 @@ class InfluxServerRule internal constructor(builder: Builder) : ExternalResource
 
     val server: InfluxServer = builder.serverBuilder.build()
 
-    val url: String = server.url
+    val url: String
+        get() = server.url
 
     constructor() : this(Builder())
 

--- a/embedded-influx-junit4/src/test/kotlin/com/bendb/influx/MultipleServerRulesTest.kt
+++ b/embedded-influx-junit4/src/test/kotlin/com/bendb/influx/MultipleServerRulesTest.kt
@@ -16,16 +16,29 @@
 package com.bendb.influx
 
 import io.kotlintest.shouldBe
+import io.kotlintest.shouldNotBe
 import org.influxdb.InfluxDBFactory
 import org.junit.Rule
 import org.junit.Test
 
-class InfluxServerRuleTest {
-    @get:Rule val serverRule = InfluxServerRule()
+class MultipleServerRulesTest {
+    @get:Rule val serverOne = InfluxServerRule()
+    @get:Rule val serverTwo = InfluxServerRule()
 
-    @Test fun `rule starts an influx server`() {
-        InfluxDBFactory.connect(serverRule.url).use { client ->
-            client.ping()?.isGood shouldBe true
+    @Test
+    fun `multiple rules will start up distinct servers`() {
+        serverOne.url shouldNotBe serverTwo.url
+
+        InfluxDBFactory.connect(serverOne.url).use { client ->
+            val pong = client.ping()
+            pong.version shouldBe "1.7.0"
+            pong.isGood shouldBe true
+        }
+
+        InfluxDBFactory.connect(serverTwo.url).use { client ->
+            val pong = client.ping()
+            pong.version shouldBe "1.7.0"
+            pong.isGood shouldBe true
         }
     }
 }

--- a/embedded-influx-junit5/src/main/kotlin/com/bendb/influx/InfluxServerExtension.kt
+++ b/embedded-influx-junit5/src/main/kotlin/com/bendb/influx/InfluxServerExtension.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018 Benjamin Bader.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.bendb.influx
 
 import org.junit.jupiter.api.extension.AfterEachCallback
@@ -6,9 +21,8 @@ import org.junit.jupiter.api.extension.Extension
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.junit.jupiter.api.extension.TestInstancePostProcessor
 
-class InfluxServerExtension(
-    private val port: Int = 8086
-) : Extension, TestInstancePostProcessor, BeforeEachCallback, AfterEachCallback {
+class InfluxServerExtension :
+    Extension, TestInstancePostProcessor, BeforeEachCallback, AfterEachCallback {
 
     private val extensionNamespace = ExtensionContext.Namespace.create(javaClass)
 
@@ -22,7 +36,7 @@ class InfluxServerExtension(
             field.isAccessible = true
             if (field.type.isAssignableFrom(InfluxServer::class.java)) {
                 val store = context.influxStore
-                val server = store.getOrComputeIfAbsent("server") { InfluxServer(port) }
+                val server = store.getOrComputeIfAbsent("server") { InfluxServer() }
 
                 field.set(testInstance, server)
             }

--- a/embedded-influx-junit5/src/test/kotlin/com/bendb/influx/InfluxServerExtensionTest.kt
+++ b/embedded-influx-junit5/src/test/kotlin/com/bendb/influx/InfluxServerExtensionTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018 Benjamin Bader.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.bendb.influx
 
 import io.kotlintest.matchers.types.shouldBeSameInstanceAs

--- a/embedded-influx/src/main/kotlin/com/bendb/influx/BinaryProvider.kt
+++ b/embedded-influx/src/main/kotlin/com/bendb/influx/BinaryProvider.kt
@@ -39,9 +39,9 @@ internal val Platform.binaryName: String
     get() = pathFromComponents(os.value, arch.value, "influxd${os.fileExtension}")
 
 internal fun copyExecutableResource(filename: String): File {
-    val tempDir = createTempDir(prefix = "embedded_influx").apply { deleteOnExit() }
+    val tempDir = createTempDir(prefix = "embedded_influx").also { ShutdownHooks.deleteRecursively(it) }
+
     val exe = File(tempDir, filename).apply {
-        deleteOnExit()
         parentFile.mkdirs()
     }
 

--- a/embedded-influx/src/main/kotlin/com/bendb/influx/InfluxServer.kt
+++ b/embedded-influx/src/main/kotlin/com/bendb/influx/InfluxServer.kt
@@ -17,6 +17,9 @@ package com.bendb.influx
 
 import java.io.Closeable
 import java.io.File
+import java.lang.Exception
+import java.net.ServerSocket
+import java.nio.file.Files
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.locks.ReentrantLock
 import java.util.function.Supplier
@@ -40,11 +43,13 @@ class InfluxServer internal constructor(builder: InfluxServerBuilder): Closeable
         @JvmStatic fun builder(): InfluxServerBuilder = InfluxServerBuilder()
     }
 
-    private val port: Int = builder.port
     private val exe = builder.executableSupplier.get()
 
+    private var backupPort: Int = 0
+    private var httpPort: Int = builder.port
+
     val url: String
-        get() = "http://127.0.0.1:$port"
+        get() = "http://127.0.0.1:$httpPort"
 
     private val lock = ReentrantLock()
     private val serverActiveCondition = lock.newCondition()
@@ -61,7 +66,36 @@ class InfluxServer internal constructor(builder: InfluxServerBuilder): Closeable
                 return
             }
 
-            val proc = ProcessBuilder(listOf(exe.absolutePath))
+            backupPort = if (backupPort == 0) findRandomPort() else backupPort
+            httpPort = if (httpPort == 0) findRandomPort() else httpPort
+
+            val rootDirectory = Files.createTempDirectory("influx").toFile()
+            val configFile = File.createTempFile("influx", ".conf", rootDirectory)
+            val metaDir = File(rootDirectory, "meta").also { it.mkdirs() }
+            val dataDir = File(rootDirectory, "data").also { it.mkdirs() }
+            val walDir = File(rootDirectory, "wal").also { it.mkdirs() }
+
+            // File#deleteOnExit doesn't handle non-empty dirs, and influx
+            // writes files that we can't cleanly incorporate into deleteOnExit;
+            // we'll just use our own version instead.
+            ShutdownHooks.deleteRecursively(rootDirectory)
+
+            configFile.writeText("""
+                reporting-disabled = true
+                bind-address = "127.0.0.1:$backupPort"
+
+                [meta]
+                dir = "$metaDir"
+
+                [data]
+                dir = "$dataDir"
+                wal-dir = "$walDir"
+
+                [http]
+                bind-address = ":$httpPort"
+            """.trimIndent())
+
+            val proc = ProcessBuilder(listOf(exe.absolutePath, "-config", configFile.absolutePath))
                 .directory(exe.parentFile)
                 .start() ?: error("Assertion failed - ProcessBuilder.start() returned null")
 
@@ -117,15 +151,31 @@ class InfluxServer internal constructor(builder: InfluxServerBuilder): Closeable
             error("Failed to stop InfluxDB")
         }
     }
+
+    @Suppress("ProtectedInFinal", "unused")
+    protected fun finalize() {
+        try {
+            process?.destroyForcibly()
+        } catch (ignored: Exception) {
+            // noop
+        }
+    }
+
+    private fun findRandomPort(): Int {
+        // ServerSockets given a port of zero will automatically
+        // find and bind to an unallocated port.  We can close
+        // the server socket and reuse its port, since we can be
+        // fairly confident that nothing else will take the port
+        // between here and starting up influx.
+        return ServerSocket(0).use {
+            it.localPort
+        }
+    }
 }
 
 class InfluxServerBuilder {
 
-    companion object {
-        private const val DEFAULT_HTTP_PORT = 8086
-    }
-
-    internal var port: Int = DEFAULT_HTTP_PORT
+    internal var port: Int = 0
     internal var executableSupplier: Supplier<File> = BinaryProvider
 
     fun port(port: Int) = apply { this.port = port}

--- a/embedded-influx/src/main/kotlin/com/bendb/influx/ShutdownHooks.kt
+++ b/embedded-influx/src/main/kotlin/com/bendb/influx/ShutdownHooks.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2018 Benjamin Bader.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.bendb.influx
+
+import java.io.File
+import java.io.IOException
+import java.nio.file.FileVisitResult
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.SimpleFileVisitor
+import java.nio.file.attribute.BasicFileAttributes
+
+internal object ShutdownHooks {
+    /**
+     * Like File#deleteOnExit(), but better.  Deletes the given directory
+     * and its contents when the VM shuts down.
+     *
+     * The return value of this method is a [Thread], which is the actual
+     * hook object.  If so desired, it can be manually run ahead-of-time,
+     * or could be unregistered from the runtime's list of shutdown hooks.
+     *
+     * @param directory the directory to be deleted
+     * @return the hook object itself.
+     */
+    internal fun deleteRecursively(directory: File): Thread {
+        return deleteRecursively(directory.toPath())
+    }
+
+    /**
+     * Like File#deleteOnExit(), but better.  Deletes the given directory
+     * and its contents when the VM shuts down.
+     *
+     * The return value of this method is a [Thread], which is the actual
+     * hook object.  If so desired, it can be manually run ahead-of-time,
+     * or could be unregistered from the runtime's list of shutdown hooks.
+     *
+     * @param path the directory to be deleted
+     * @return the hook object itself.
+     */
+    internal fun deleteRecursively(path: Path): Thread {
+        val hook = Thread {
+            try {
+                Files.walkFileTree(path, DeleteAllTheThings)
+            } catch (e: IOException) {
+                // whoops!
+            }
+
+            Files.deleteIfExists(path)
+        }
+
+        Runtime.getRuntime().addShutdownHook(hook)
+
+        return hook
+    }
+}
+
+private object DeleteAllTheThings : SimpleFileVisitor<Path>() {
+    override fun visitFile(file: Path?, attrs: BasicFileAttributes?): FileVisitResult {
+        if (file != null) {
+            Files.deleteIfExists(file)
+        }
+        return FileVisitResult.CONTINUE
+    }
+
+    override fun postVisitDirectory(dir: Path?, exc: IOException?): FileVisitResult {
+        if (dir != null && exc == null) {
+            Files.deleteIfExists(dir)
+        }
+        return FileVisitResult.CONTINUE
+    }
+}

--- a/embedded-influx/src/test/kotlin/com/bendb/influx/InfluxServerTest.kt
+++ b/embedded-influx/src/test/kotlin/com/bendb/influx/InfluxServerTest.kt
@@ -18,11 +18,15 @@ package com.bendb.influx
 import io.kotlintest.matchers.types.shouldBeSameInstanceAs
 import io.kotlintest.shouldBe
 import org.influxdb.InfluxDBFactory
+import org.influxdb.dto.BatchPoints
+import org.influxdb.dto.Point
+import org.influxdb.dto.Query
 import org.junit.Test
+import java.util.concurrent.TimeUnit
 
 class InfluxServerTest {
-    @Test fun `builder default port is 8086`() {
-        InfluxServerBuilder().port shouldBe 8086
+    @Test fun `builder default port is "undefined"`() {
+        InfluxServerBuilder().port shouldBe 0
     }
 
     @Test fun `builder binary supplier is BinaryProvider by default`() {
@@ -35,6 +39,42 @@ class InfluxServerTest {
 
             InfluxDBFactory.connect("http://127.0.0.1:8086").use { client ->
                 client.ping()?.isGood shouldBe true
+            }
+        }
+    }
+
+    @Test fun `data written to one server will not be readable from another`() {
+        InfluxServer().use { server ->
+            server.start()
+
+            InfluxDBFactory.connect(server.url).use { client ->
+                client.createDatabase("sample")
+                client.createRetentionPolicy("default", "sample", "30d", 1, true)
+
+                val point = Point.measurement("memory")
+                    .time(System.currentTimeMillis(), TimeUnit.MILLISECONDS)
+                    .addField("a", 1L)
+                    .addField("b", 2L)
+                    .build()
+                client.write(BatchPoints.database("sample").point(point).build())
+
+                val result = client.query(Query("select * from memory", "sample"))
+                result.results.size shouldBe 1
+
+                val series = result.results[0]
+                series.hasError() shouldBe false
+                series.series[0].name shouldBe "memory"
+            }
+        }
+
+        InfluxServer().use { server ->
+            server.start()
+            InfluxDBFactory.connect(server.url).use { client ->
+                val result = client.query(Query("select * from memory", "sample"))
+                result.results.size shouldBe 1
+
+                val series = result.results[0]
+                series.hasError() shouldBe true
             }
         }
     }

--- a/embedded-influx/src/test/kotlin/com/bendb/influx/ShutdownHooksTest.kt
+++ b/embedded-influx/src/test/kotlin/com/bendb/influx/ShutdownHooksTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018 Benjamin Bader.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.bendb.influx
+
+import io.kotlintest.matchers.file.exist
+import io.kotlintest.should
+import io.kotlintest.shouldNot
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class ShutdownHooksTest {
+    @get:Rule val tempDir = TemporaryFolder()
+
+    @Test
+    fun `deleteRecursively deletes non-empty directories`() {
+        val dir = tempDir.newFolder()
+        val file = File(dir, "test.txt")
+        file.writeText("foo")
+
+        val hook = ShutdownHooks.deleteRecursively(dir)
+        Runtime.getRuntime().removeShutdownHook(hook) // We are running the hook ourselves here
+
+        dir should exist()
+        file should exist()
+
+        hook.run()
+
+        dir shouldNot exist()
+        file shouldNot exist()
+    }
+
+    @Test
+    fun `deleteRecursively does not crash if the directory does not exist`() {
+        val dir = File("foo")
+        val hook = ShutdownHooks.deleteRecursively(dir)
+        Runtime.getRuntime().removeShutdownHook(hook)
+
+        hook.run()
+    }
+
+    @Test
+    fun `deleteRecursively handles files too`() {
+        val file = tempDir.newFile()
+        file.writeText("blah")
+
+        val hook = ShutdownHooks.deleteRecursively(file)
+        Runtime.getRuntime().removeShutdownHook(hook) // We are running the hook ourselves here
+
+        file should exist()
+        hook.run()
+        file shouldNot exist()
+    }
+}


### PR DESCRIPTION
This uncovered a bad assumption I'd made about File#deleteOnExit, which does not actually delete non-empty directories.  To work around, this commit adds a custom shutdown hook to recursively delete file trees.

This commit also includes logic to prevent multiple InfluxServer instances from trying to use the same port.

Also adding missing license headers.