### PR TITLE
Use a synchronized lock to check if the server has started

### DIFF
--- a/embedded-influx/src/main/kotlin/com/bendb/influx/InfluxServer.kt
+++ b/embedded-influx/src/main/kotlin/com/bendb/influx/InfluxServer.kt
@@ -121,7 +121,11 @@ class InfluxServer internal constructor(builder: InfluxServerBuilder): Closeable
 
             val deadline = System.currentTimeMillis() + timeout.toMillis()
 
-            while (!started) {
+            while (true) {
+                val finished = lock.withLock { started }
+                if (finished) {
+                    break
+                }
                 val toWait = deadline - System.currentTimeMillis()
                 if (toWait < 0) {
                     proc.destroy()


### PR DESCRIPTION
- We frequently see issues with the server not starting (even after 10 seconds).  This removes the possibility that there is a thread synchronization issue causing the timeout to occur.