### PR TITLE
Add Junit5 extension for Influx Server instance fields

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ subprojects {
                 ],
                 junit4: [ "junit:junit:$junit4Version" ],
                 junit5: [
-                        "org.junit:junit-bom:$junit5Version"
+                        "org.junit.jupiter:junit-jupiter-engine:$junit5Version"
                 ],
                 junit5Api: [
                         "org.junit.jupiter:junit-jupiter-api:$junit5Version"

--- a/embedded-influx-junit5/build.gradle
+++ b/embedded-influx-junit5/build.gradle
@@ -23,4 +23,10 @@ dependencies {
     testImplementation libs.influxClient
     testImplementation libs.junit5
     testImplementation libs.kotlinTest
+    
+}
+
+test {
+    useJUnitPlatform {
+    } 
 }

--- a/embedded-influx-junit5/src/main/kotlin/com/bendb/influx/InfluxServerInstance.kt
+++ b/embedded-influx-junit5/src/main/kotlin/com/bendb/influx/InfluxServerInstance.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Benjamin Bader.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.bendb.influx
 
 import org.junit.jupiter.api.extension.AfterEachCallback
@@ -22,8 +38,9 @@ import org.junit.jupiter.api.extension.ExtensionContext
  *
  *     @Test fun pingThatServer() {
  *         InfluxDBFactory.connect(server.url).use { client ->
- *         val pong = client.ping()
- *         pong?.isGood shouldBe true
+ *             val pong = client.ping()
+ *             pong?.isGood shouldBe true
+ *         }
  *     }
  * }
  * ```

--- a/embedded-influx-junit5/src/main/kotlin/com/bendb/influx/InfluxServerInstance.kt
+++ b/embedded-influx-junit5/src/main/kotlin/com/bendb/influx/InfluxServerInstance.kt
@@ -1,0 +1,47 @@
+package com.bendb.influx
+
+import org.junit.jupiter.api.extension.AfterEachCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+
+/**
+ * [InfluxServerInstance] is a JUnit 5 extension which creates a new [InfluxServer] for each field using
+ * the extension.
+ *
+ * This extension differs from [InfluxServerExtension] in that it will create a new [InfluxServer] for each
+ * instance variable it is registered to.  Moreover, it allows the callers to configure the server by way
+ * of the [InfluxServerBuilder].
+ *
+ * Example usage:
+ *
+ * ```
+ * class ExampleTest {
+ *     @JvmField
+ *     @RegisterExtension
+ *     val server = InfluxServerInstance(InfluxServerBuilder().timeout(Duration.ofSeconds(10)))
+ *
+ *     @Test fun pingThatServer() {
+ *         InfluxDBFactory.connect(server.url).use { client ->
+ *         val pong = client.ping()
+ *         pong?.isGood shouldBe true
+ *     }
+ * }
+ * ```
+ */
+class InfluxServerInstance(
+    private val builder: InfluxServerBuilder = InfluxServerBuilder()
+) : BeforeEachCallback, AfterEachCallback {
+    lateinit var server: InfluxServer
+
+    val url: String
+        get() = server.url
+
+    override fun beforeEach(context: ExtensionContext) {
+        server = builder.build()
+        server.start()
+    }
+
+    override fun afterEach(context: ExtensionContext) {
+        server.close()
+    }
+}

--- a/embedded-influx-junit5/src/test/kotlin/com/bendb/influx/InfluxServerInstanceTest.kt
+++ b/embedded-influx-junit5/src/test/kotlin/com/bendb/influx/InfluxServerInstanceTest.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 Benjamin Bader.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.bendb.influx
+
+import io.kotlintest.matchers.types.shouldNotBeSameInstanceAs
+import io.kotlintest.shouldBe
+import org.influxdb.InfluxDBFactory
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+
+class InfluxServerInstanceTest {
+    @JvmField
+    @RegisterExtension
+    val server = InfluxServerInstance()
+
+    @JvmField
+    @RegisterExtension
+    val otherServer = InfluxServerInstance()
+
+    @Test fun serverIsInjectedAndRunning() {
+        InfluxDBFactory.connect(server.url).use { client ->
+            val pong = client.ping()
+            pong?.isGood shouldBe true
+        }
+    }
+
+    @Test fun twoServerInstancesAreInjected() {
+        server.shouldNotBeSameInstanceAs(otherServer)
+    }
+}


### PR DESCRIPTION
Add Junit5 extension for Influx Server instance fields

- Also fixed build which was not actually running the tests for the embedded-influx-junit5 module